### PR TITLE
[meta] exclude more files from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,10 @@
 	},
 	"publishConfig": {
 		"ignore": [
-			".github/workflows"
+			".github/workflows",
+			"test",
+			".eslintrc",
+			".nycrc"
 		]
 	}
 }


### PR DESCRIPTION
Dot-files should not be included and tests are also not necessary in the published package. Reducing the size of the package benefits everyone (and, in this case, the number of removed bytes outweighs the number of bytes added to the manifest).

Following/based on 3e6de84f959c1ecc44e894aa1a64a8eb5007f3f5